### PR TITLE
Update api versions from v1beta1 to v1

### DIFF
--- a/config/ce-default-k8s-cluster-role.yaml
+++ b/config/ce-default-k8s-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ce
@@ -18,7 +18,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ce-clusterrolebinding


### PR DESCRIPTION
RBAC was promoted to v1 in k8s 1.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/continuous-efficiency/1)
<!-- Reviewable:end -->
